### PR TITLE
small fix for a crash on some type of RTFs

### DIFF
--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -452,7 +452,10 @@ class Group(object):
             self.fontNum = int(fontNum)
             self._setFontCharset()
         elif self.charsetTable is not None:
-            self.charset = self.charsetTable[int(fontNum)]
+            try:
+                self.charset = self.charsetTable[int(fontNum)]
+            except KeyError: # fontNum not found in charsetTable, just ignore
+                pass
 
     def handle_fcharset(self, charsetNum):
         if 'FONT_TABLE' in (self.parent.specialMeaning, self.specialMeaning):


### PR DESCRIPTION
Some RTFs contain fontNum=0 without declaring it, which makes the RtfReader fail.
I didn't really read the RTF specs, so accept my appologies in advance if this bug in the RTFs is illegal and  should actually fail the parsing. I found many of these RTFs in the Israeli Knesset website which I use pyth to read.
