### PR TITLE
Fixed tests in test_writepdf.py

### DIFF
--- a/tests/test_writepdf.py
+++ b/tests/test_writepdf.py
@@ -80,13 +80,13 @@ class TestWritePDF(unittest.TestCase):
 
     def test_latex(self):
         doc = PythonReader.read(P[u"the-text"])
-        pdf = PDFWriter.write(doc, method='latex').getvalue()
+        pdf = PDFWriter.write(doc).getvalue()
         html = self.pdf_to_html(pdf)
         assert "the-text" in html, html
 
     def test_rst(self):
         doc = PythonReader.read(P[u"the-text"])
-        pdf = PDFWriter.write(doc, method='rst').getvalue()
+        pdf = PDFWriter.write(doc).getvalue()
         print pdf
         html = self.pdf_to_html(pdf)
         assert "the-text" in html, html


### PR DESCRIPTION
Two tests in test_writepdf.py are failing because PDFWriter.write was refactored in git rev
d87f7877cca5ea90c2d79979521a3db77c47eb30 loosing "method" argument.
 I have simply fixed PDFWriter.write signature but test_latex and test_rst due to PDFWriter.write refactoring now are testing the same thing.

I'm using this simple patch in the official pyth package for Debian.
