### PR TITLE
fix handle_ansi_escape

### DIFF
--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -473,6 +473,7 @@ class Group(object):
 
 
     def handle_ansi_escape(self, code):
+        code2 = code
         code = int(code, 16)
 
         if isinstance(self.charset, dict):
@@ -483,7 +484,11 @@ class Group(object):
                 char = unichr(uni_code)
 
         else:
-            char = chr(code).decode(self.charset, self.reader.errors)
+            if self.charset == 'cp932':
+                code = '0x' + code2
+                char = code.decode(self.charset, self.reader.errors)
+            else:
+                char = chr(code).decode(self.charset, self.reader.errors)
 
         self.content.append(char)
 

--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -489,7 +489,6 @@ class Group(object):
                 char = code.decode(self.charset, self.reader.errors)
             else:
                 char = chr(code).decode(self.charset, self.reader.errors)
-
         self.content.append(char)
 
 

--- a/tests/test.rtf
+++ b/tests/test.rtf
@@ -1,0 +1,19 @@
+{\rtf1\ansi\deff0\adeflang1025
+{\fonttbl{\f0\froman\fprq2\fcharset128 Times New Roman;}{\f1\froman\fprq2\fcharset128 Times New Roman;}{\f2\fswiss\fprq2\fcharset128 Arial;}{\f3\fnil\fprq2\fcharset128 Arial Unicode MS;}}
+{\colortbl;\red0\green0\blue0;\red128\green128\blue128;}
+{\stylesheet{\s1\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\af3\afs24\lang1081\ltrch\dbch\af3\langfe2052\hich\f0\fs24\lang9\loch\f0\fs24\lang9\snext1 Normal;}
+{\s2\sb240\sa120\keepn\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\afs28\lang1081\ltrch\dbch\langfe2052\hich\f2\fs28\lang9\loch\f2\fs28\lang9\sbasedon1\snext3 Heading;}
+{\s3\sa120\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\af3\afs24\lang1081\ltrch\dbch\af3\langfe2052\hich\f0\fs24\lang9\loch\f0\fs24\lang9\sbasedon1\snext3 Body Text;}
+{\s4\sa120\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\af3\afs24\lang1081\ltrch\dbch\af3\langfe2052\hich\f0\fs24\lang9\loch\f0\fs24\lang9\sbasedon3\snext4 List;}
+{\s5\sb120\sa120\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\af3\afs24\lang1081\ai\ltrch\dbch\af3\langfe2052\hich\f0\fs24\lang9\i\loch\f0\fs24\lang9\i\sbasedon1\snext5 caption;}
+{\s6\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\af3\afs24\lang1081\ltrch\dbch\af3\langfe2052\hich\f0\fs24\lang9\loch\f0\fs24\lang9\sbasedon1\snext6 Index;}
+}
+{\info{\author Boris Shemigon}{\creatim\yr2011\mo6\dy30\hr11\min11}{\revtim\yr0\mo0\dy0\hr0\min0}{\printim\yr0\mo0\dy0\hr0\min0}{\comment StarWriter}{\vern3300}}\deftab709
+{\*\pgdsctbl
+{\pgdsc0\pgdscuse195\pgwsxn11906\pghsxn16838\marglsxn1134\margrsxn1134\margtsxn1134\margbsxn1134\pgdscnxt0 Standard;}}
+\paperh16838\paperw11906\margl1134\margr1134\margt1134\margb1134\sectd\sbknone\pgwsxn11906\pghsxn16838\marglsxn1134\margrsxn1134\margtsxn1134\margbsxn1134\ftnbj\ftnstart1\ftnrstcont\ftnnar\aenddoc\aftnrstcont\aftnstart1\aftnnrlc
+\pard\plain \ltrpar\s1\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\af3\afs24\lang1081\ltrch\dbch\af3\langfe2052\hich\f0\fs24\lang9\loch\f0\fs24\lang9 {\rtlch \ltrch\loch\f0\fs24\lang9\i0\b0 Apostrophe: `}
+\par \pard\plain \ltrpar\s1\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\af3\afs24\lang1081\ltrch\dbch\af3\langfe2052\hich\f0\fs24\lang9\loch\f0\fs24\lang9 {\rtlch \ltrch\loch\f0\fs24\lang9\i0\b0 Quotation mark: ' \'81\'67}
+\par \pard\plain \ltrpar\s1\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\af3\afs24\lang1081\ltrch\dbch\af3\langfe2052\hich\f0\fs24\lang9\loch\f0\fs24\lang9 
+\par \pard\plain \ltrpar\s1\cf0{\*\hyphen2\hyphlead2\hyphtrail2\hyphmax0}\rtlch\af3\afs24\lang1081\ltrch\dbch\af3\langfe2052\hich\f0\fs24\lang9\loch\f0\fs24\lang9 {\rtlch \ltrch\loch\f0\fs24\lang9\i0\b0 ` ~ ! @ # $ % ^ & * ( ) - _ = + [ \{ ] \} \\ | ; : ' \'81\'67 , < . > / ?}
+\par }

--- a/tests/test_readrtf15.py
+++ b/tests/test_readrtf15.py
@@ -1,0 +1,35 @@
+
+"""
+Unit tests of the xhtml reader.
+"""
+
+import unittest
+import pyth.document
+from pyth.plugins.rtf15.reader import Rtf15Reader
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from StringIO import StringIO
+
+
+class TestReadXHTML(unittest.TestCase):
+
+    def test_basic(self):
+        """
+        Try to read an empty rtf document
+        """
+        rtf = open('test.rtf', 'rb')
+        rtf = rtf.read()
+        # Read file content by chunks
+        content = StringIO()
+        content.write(rtf)
+
+        content.seek(0)
+        doc = Rtf15Reader.read(content)
+        self.assert_(isinstance(doc.content[0], pyth.document.Paragraph))
+        self.assert_(doc.content[2].content[0].content[0],
+                     u"[` ~ ! @ # $ % ^ & * ( ) - _ = + [ { ] } \ | ; : ' 0x810x67 , < . > / ?]")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
>>> chr(129)
'\x81'
>>> char = '\x81'.decode('cp932')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'cp932' codec can't decode byte 0x81 in position 0: incomplete multibyte sequence

I made a temporary solution for def handle_ansi_escape(self, code): in rtf15.reader.py
 