### PR TITLE
Handle tabs instead of discarding them

### DIFF
--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -580,6 +580,8 @@ class Group(object):
     def handle_rdblquote(self):
         self.content.append(u'\u201D')
 
+    def handle_tab(self):
+        self.content.append(u'\t')
 
     def handle_field(self):
         def finalize():


### PR DESCRIPTION
The commit in this pull request adds handling for tabs (`\tab`) in rtf files. This pull request is related to my previous one. I require the white space on lines to be exact for a project a work on. The tabs were lacking in this count.
