### PR TITLE
Fixed escaping HTML entities within strings behavior change in  python-beautifulsoup 3.2.1

### DIFF
--- a/pyth/plugins/xhtml/reader.py
+++ b/pyth/plugins/xhtml/reader.py
@@ -55,7 +55,7 @@ class XHTMLReader(PythReader):
                 text = unicode(node)
                 lines = [x.strip() for x in text.splitlines()]
                 text = ' '.join(lines)
-                node.replaceWith(text)
+                node.replaceWith(BeautifulSoup.BeautifulSoup(text))
         soup = BeautifulSoup.BeautifulSoup(unicode(soup))
         # replace all <br/> tag by newline character
         for node in soup.findAll('br'):


### PR DESCRIPTION
Hello,
in this beautifulsoap revision http://bazaar.launchpad.net/~leonardr/beautifulsoup/3.2/revision/44 there is a behavior change to escape XML entities within strings.
A detailed description is here: https://bugs.launchpad.net/beautifulsoup/+bug/949074 
I'm using this patch in the official Debian package for pyth to make test_readxhtml.py not fail (see
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=678754).

Kind regards,
Daniele Tricoli
