### PR TITLE
Handle rtf's with missing fontNum in charsetTable

### DIFF
--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -460,8 +460,12 @@ class Group(object):
         elif self.charsetTable is not None:
             try:
                 self.charset = self.charsetTable[int(fontNum)]
-            except KeyError:  # fontNum not found in charsetTable, just ignore
-                pass
+            except KeyError:
+                # fontNum not found in charsetTable, ignore if requested
+                if self.reader.errors == 'ignore':
+                    pass
+                else:
+                    raise
 
     def handle_fcharset(self, charsetNum):
         if 'FONT_TABLE' in (self.parent.specialMeaning, self.specialMeaning):


### PR DESCRIPTION
This simply ignores the situation with broken rtf's, instead of non handled
exception.
