### PR TITLE
Added callback function to xhtml reader, which could be used to make absolute paths

### DIFF
--- a/pyth/plugins/xhtml/reader.py
+++ b/pyth/plugins/xhtml/reader.py
@@ -12,15 +12,15 @@ from pyth.plugins.xhtml.css import CSS
 class XHTMLReader(PythReader):
 
     @classmethod
-    def read(self, source, css_source=None, encoding="utf-8", default_url=None):
-        reader = XHTMLReader(source, css_source, encoding, default_url)
+    def read(self, source, css_source=None, encoding="utf-8", link_callback=None):
+        reader = XHTMLReader(source, css_source, encoding, link_callback)
         return reader.go()
 
-    def __init__(self, source, css_source=None, encoding="utf-8", default_url=None):
+    def __init__(self, source, css_source=None, encoding="utf-8", link_callback=None):
         self.source = source
         self.css_source = css_source
         self.encoding = encoding
-        self.default_url = default_url
+        self.link_callback = link_callback
 
     def go(self):
         soup = BeautifulSoup.BeautifulSoup(self.source,
@@ -105,15 +105,10 @@ class XHTMLReader(PythReader):
         if not a_node:
             return None
 
-        if self.default_url is None:
+        if self.link_callback is None:
             return a_node.get('href')
-
-        if a_node.get('href').startswith("http://"):
-            return a_node.get('href')
-        elif a_node.get('href').startswith("/"):
-            return self.default_url + a_node.get('href')
         else:
-            return self.default_url + "/" + a_node.get('href')
+            return self.link_callback(a_node.get('href'))
 
     def process_text(self, node):
         """


### PR DESCRIPTION
Sometimes you need to dump html page and then save it to pdf, but it'll raise an exception, because of relative paths in urls
i added additional callback function, which user can use to make absolute paths in urls, same thing i've seen in pisa(https://pypi.python.org/pypi/pisa/)
here is simple example:

```
from pyth.plugins.xhtml.reader import XHTMLReader

content = """
text<br>
<a href="/relative/path/to/something">link</a><br>
text
"""

def link_callback(url):
    return "http://domain.com" + url


doc=XHTMLReader.read(content, link_callback=link_callback)
print str(doc.content[1].content)
```

That, what i needed:

```
[Text('[link]' {'url': u'http://domain.com/relative/path/to/something'})]
```
