### PR TITLE
Superscript fix

### DIFF
--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -590,7 +590,7 @@ class Group(object):
 
     def handle_super(self):
         self.content.append(ReadableMarker("super", True))
-    
+
     #Turns off superscripting or subscripting
     def handle_nosupersub(self):
         self.content.append(ReadableMarker("sub", False))


### PR DESCRIPTION
Adds support for the \nosupersub rtf control word. It cancels existing super or subscripts. 
