### PR TITLE
Fix codecs search function to only match 'symbol'

### DIFF
--- a/pyth/encodings/symbol.py
+++ b/pyth/encodings/symbol.py
@@ -96,7 +96,8 @@ info = codecs.CodecInfo(
 )
 
 def search(name):
-    # What the hell is this actually supposed to do?
-    return info
+    if name == info.name:
+        return info
+    return None
 
 codecs.register(search)


### PR DESCRIPTION
The current search function matches all encodings, which break other packages that use the `codecs` registry like [`cssutils`](https://bitbucket.org/cthedot/cssutils/src/d572ac8df6bd18cad203dea1bbf58867ff0d0ebe/src/cssutils/_codec2.py#cl-565). According to the [`codecs` documentation](https://docs.python.org/2/library/codecs.html):

> In case a search function cannot find a given encoding, it should return `None`.

This pull request fixes the search function to only match `'symbol'`.

Before:

```
>>> from pyth.plugins.rtf15.reader import Rtf15Reader
>>> import codecs
>>> print codecs.getdecoder('symbol')
<function symbol_decode at 0x109774140>
>>> print codecs.getdecoder('<some_encoding>')
<function symbol_decode at 0x109774140>
```

After:

```
>>> from pyth.plugins.rtf15.reader import Rtf15Reader
>>> import codecs
>>> print codecs.getdecoder('symbol')
<function symbol_decode at 0x1043b3140>
>>> print codecs.getdecoder('<some_encoding>')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/somakrdas/.envs/work/lib/python2.7/codecs.py", line 946, in getdecoder
    return lookup(encoding).decode
LookupError: unknown encoding: <some_encoding>
```
