### PR TITLE
add *.egg-info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
-*.pyc
+*.py[co]
+*.egg-info


### PR DESCRIPTION
When installing pyth as editable in pip (`pip install -e path/to/pyth`), python creates an pyth.egg-info folder. Of course this folder does not belong into git, so updating the .gitignore should make everyone's life easier.
