### PR TITLE
Control "f0" in RTF file from Mac OS X could not resolve charset.

### DIFF
--- a/pyth/encodings/symbol.py
+++ b/pyth/encodings/symbol.py
@@ -100,4 +100,4 @@ def search(name):
         return info
     return None
 
-codecs.register(search)
+#codecs.register(search)

--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -485,15 +485,20 @@ class Group(object):
         if 'FONT_TABLE' in (self.parent.specialMeaning, self.specialMeaning):
             self.fontNum = int(fontNum)
             self._setFontCharset()
-        elif self.charsetTable is not None:
-            try:
-                self.charset = self.charsetTable[int(fontNum)]
-            except KeyError:
-                # fontNum not found in charsetTable, ignore if requested
-                if self.reader.errors == 'ignore':
-                    pass
-                else:
-                    raise
+        else:
+            charsetTable = self.charsetTable
+            if not charsetTable:
+                charsetTable = self.reader.charsetTable
+
+            if charsetTable is not None:
+                try:
+                    self.charset = charsetTable[int(fontNum)]
+                except KeyError:
+                    # fontNum not found in charsetTable, ignore if requested
+                    if self.reader.errors == 'ignore':
+                        pass
+                    else:
+                        raise
 
     def handle_fcharset(self, charsetNum):
         if 'FONT_TABLE' in (self.parent.specialMeaning, self.specialMeaning):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name="pyth",
-      version="0.6.0",
+      version="0.6.1",
       packages = find_packages(),
       zip_safe = False,
 

--- a/tests/test_readosxrtf.py
+++ b/tests/test_readosxrtf.py
@@ -1,0 +1,24 @@
+
+# -*- coding: UTF-8 -*-
+"""
+Unit tests of the rtf15 reader.
+"""
+
+import unittest
+
+from pyth.plugins.rtf15.reader import Rtf15Reader
+from pyth.plugins.plaintext.writer import PlaintextWriter
+from StringIO import StringIO
+
+class TestReadOSXRtf(unittest.TestCase):
+
+    def test_read(self):
+        rtf = StringIO("""{\\rtf1\\ansi\\ansicpg1252\\cocoartf1343\\cocoasubrtf160\\cocoascreenfonts1{\\fonttbl\\f0\\fnil\\fcharset222 Thonburi;}
+{\\colortbl;\\red255\\green255\\blue255;}
+\\pard\\tx560\\tx1120\\tx1680\\tx2240\\tx2800\\tx3360\\tx3920\\tx4480\\tx5040\\tx5600\\tx6160\\tx6720\\pardirnatural\\qc
+
+\\f0\\fs24 \\cf0 \\'b9\\'e9\\'d3\\'b5\\'a1""")
+        doc = Rtf15Reader.read(rtf)
+        text = PlaintextWriter.write(doc).read()
+        print text
+        self.assertEquals(u"น้ำตก", text.decode('utf8'))

--- a/tests/test_readosxrtf.py
+++ b/tests/test_readosxrtf.py
@@ -22,3 +22,15 @@ class TestReadOSXRtf(unittest.TestCase):
         text = PlaintextWriter.write(doc).read()
         print text
         self.assertEquals(u"น้ำตก", text.decode('utf8'))
+
+
+    def test_read2(self):
+        rtf = StringIO("""{\\rtf1\\ansi\\ansicpg1252\\cocoartf1343\\cocoasubrtf160\\cocoascreenfonts1{\\fonttbl\\f0\\fnil\\fcharset222 Thonburi;}
+{\\colortbl;\\red255\\green255\\blue255;}
+\\pard\\tx560\\tx1120\\tx1680\\tx2240\\tx2800\\tx3360\\tx3920\\tx4480\\tx5040\\tx5600\\tx6160\\tx6720\\pardirnatural\\qc
+
+{\\f0\\fs24 \\cf0 \\'b9\\'e9\\'d3\\'b5\\'a1}""")
+        doc = Rtf15Reader.read(rtf)
+        text = PlaintextWriter.write(doc).read()
+        print text
+        self.assertEquals(u"น้ำตก", text.decode('utf8'))


### PR DESCRIPTION
When using Rtf15Reader with rtf file from Mac OS X. The ascii-escape character decoding is using a wrong charset due to control "f0" is fail to resolve charset from charsetTable.

In this patch, I 'm provide a unit test for this scenario.
