### PR TITLE
error wasn't ignored when ordered to do so

### DIFF
--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -469,7 +469,10 @@ class Group(object):
         if codepage in _CODEPAGES_BY_NUMBER:
             self.charset = self.reader.charset = _CODEPAGES_BY_NUMBER[codepage]
         else:
-            raise ValueError("Unknown codepage %s" % codepage)
+            if self.reader.errors == 'ignore':
+                pass
+            else:
+                raise ValueError("Unknown codepage %s" % codepage)
 
 
     def handle_fonttbl(self):


### PR DESCRIPTION
ignore codepage errors on `errors='ignore'` when reading rtf.

`doc = Rtf15Reader.read(filebuffer, errors='ignore')` raised an exception when it shouldn't. 
