### PR TITLE
Don't strip properties from whitespace-only runs

### DIFF
--- a/pyth/plugins/rtf15/reader.py
+++ b/pyth/plugins/rtf15/reader.py
@@ -263,11 +263,6 @@ class DocBuilder(object):
             else:
                 continue
 
-            # For whitespace-only groups, remove any property stuff,
-            # to avoid extra markup in output
-            if not run.content[0].strip():
-                run.properties = {}
-
             # Join runs only if their properties match
             if joinedRuns and (run.properties == joinedRuns[-1].properties):
                 joinedRuns[-1].content[0] += run.content[0]


### PR DESCRIPTION
I think this is a slightly-too-aggressive optimisation - the width of a space can be important, and stripping properties throws away that information.

Thanks for this project!